### PR TITLE
fix: volume-independent beat sync, pause on inactive & lag/ visual jump issues

### DIFF
--- a/contents/lib/audioAnalysis.ts
+++ b/contents/lib/audioAnalysis.ts
@@ -13,6 +13,9 @@ interface AudioAnalysisState {
   initTimeoutId: number | null;
   resumeContextHandler: (() => Promise<void>) | null;
   volumeChangeHandler: (() => void) | null;
+  playHandler: (() => void) | null;
+  pauseHandler: (() => void) | null;
+  onPlaybackStateChange: ((isPlaying: boolean) => void) | null;
 }
 
 const state: AudioAnalysisState = {
@@ -27,6 +30,9 @@ const state: AudioAnalysisState = {
   initTimeoutId: null,
   resumeContextHandler: null,
   volumeChangeHandler: null,
+  playHandler: null,
+  pauseHandler: null,
+  onPlaybackStateChange: null,
 };
 
 const ANALYSIS_INTERVAL = 100;
@@ -112,6 +118,19 @@ export const initializeAudioAnalysis = async (): Promise<void> => {
     };
     state.element.addEventListener("volumechange", state.volumeChangeHandler);
 
+    state.playHandler = () => {
+      if (state.onPlaybackStateChange) {
+        state.onPlaybackStateChange(true);
+      }
+    };
+    state.pauseHandler = () => {
+      if (state.onPlaybackStateChange) {
+        state.onPlaybackStateChange(false);
+      }
+    };
+    state.element.addEventListener("play", state.playHandler);
+    state.element.addEventListener("pause", state.pauseHandler);
+
     state.isInitialized = true;
     logger.log("Audio analysis initialized (volume-independent)");
   } catch (error) {
@@ -192,3 +211,11 @@ export const stopAudioAnalysis = (): void => {
 };
 
 export const isAudioInitialized = (): boolean => state.isInitialized;
+
+export const setPlaybackStateCallback = (callback: ((isPlaying: boolean) => void) | null): void => {
+  state.onPlaybackStateChange = callback;
+};
+
+export const isPlaying = (): boolean => {
+  return state.element ? !state.element.paused : false;
+};

--- a/contents/youtube-music.ts
+++ b/contents/youtube-music.ts
@@ -37,6 +37,9 @@ const initializeApp = async (): Promise<void> => {
     },
   });
 
+  // Initialize audio analysis early to avoid lag when song starts
+  audioAnalysis.initializeAudioAnalysis();
+
   setTimeout(async () => {
     await gradientController.checkAndUpdateGradient();
 
@@ -53,10 +56,7 @@ const initializeApp = async (): Promise<void> => {
       }
     }
 
-    setTimeout(async () => {
-      await audioAnalysis.initializeAudioAnalysis();
-      gradientController.startAudioIfEnabled();
-    }, 2000);
+    gradientController.startAudioIfEnabled();
 
     navigationManager.initialize(gradientController.checkAndUpdateGradient, gradientController.resetImageTracking);
   }, 0);

--- a/shared/constants/gradientSettings.ts
+++ b/shared/constants/gradientSettings.ts
@@ -25,6 +25,7 @@ export interface GradientSettings {
   audioSpeedMultiplier: number;
   audioScaleBoost: number;
   audioBeatThreshold: number;
+  pauseOnInactive: boolean;
   // Other settings
   showLogs: boolean;
   boostDullColors: boolean;
@@ -65,6 +66,7 @@ export const DEFAULT_GRADIENT_SETTINGS: GradientSettings = {
   audioSpeedMultiplier: 4,
   audioScaleBoost: 2,
   audioBeatThreshold: 0.105,
+  pauseOnInactive: true,
   // Other settings
   showLogs: false,
   boostDullColors: true,


### PR DESCRIPTION
# Changes
  - Beat detection now works independently of YTM's volume slider (uses GainNode routing)
  - Animation pauses when song is paused, with smooth lerp transition #6 
  - Fixed visual shader skips on first song load (300ms delay before fade-in)
  - Fixed audio lag on first song (early audio context initialization)