### PR TITLE
fix: ship firefox artwork host permission in release builds

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -84,6 +84,10 @@ jobs:
           run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure Firefox artwork host
+        if: steps.download.outcome != 'success'
+        run: echo 'PLASMO_PUBLIC_ARTWORK_HOST=https://artwork.boidu.dev/*' > .env.firefox
+
       - name: Rebuild extension (fallback)
         if: steps.download.outcome != 'success'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Update version
         run: bun tooling/update-version.ts ${{ github.event.inputs.version }}
 
+      - name: Configure Firefox artwork host
+        run: echo 'PLASMO_PUBLIC_ARTWORK_HOST=https://artwork.boidu.dev/*' > .env.firefox
+
       - name: Build all targets
         run: bun run build
 


### PR DESCRIPTION
## Overview

The artwork.boidu.dev host permission was getting dropped from released Firefox builds. It only lives in a gitignored .env.firefox, and CI never had that file, so Firefox killed the animated-art fetch with a network error. I made the release and publish workflows write .env.firefox before building, so the permission actually ships. It stays Firefox-only: Plasmo only reads that file for the firefox-mv2 target, so Chrome and Edge don't pick up a new permission.
