### PR TITLE
feat: render kawarp in the floating lyrics window

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
     "lineEnding": "lf",
     "lineWidth": 120,
     "attributePosition": "auto",
-    "ignore": ["build", "node_modules", ".plasmo"]
+    "ignore": ["build", "node_modules", ".plasmo", "package.json"]
   },
   "organizeImports": { "enabled": true },
   "linter": {

--- a/contents/lib/gradientController.ts
+++ b/contents/lib/gradientController.ts
@@ -7,6 +7,7 @@ import { logger } from "@/shared/utils/logger";
 import * as animatedArtManager from "./animatedArtManager";
 import * as audioAnalysis from "./audioAnalysis";
 import * as kawarpManager from "./kawarpManager";
+import * as pipManager from "./pipManager";
 import * as storage from "./storage";
 
 let gradientSettings: GradientSettings;
@@ -178,6 +179,7 @@ export const updateGradientSettings = async (settings: GradientSettings): Promis
         audioAnalysis.startAudioAnalysis(settings, handleBeatDetected);
       }
     }
+    pipManager.sync();
     return;
   }
 

--- a/contents/lib/kawarpManager.ts
+++ b/contents/lib/kawarpManager.ts
@@ -268,11 +268,12 @@ export const createKawarp = async (
     return false;
   }
 
-  const state = getKawarpState(location);
+  let state = getKawarpState(location);
 
   if (state.instance) {
     logger.log(`Kawarp already exists for ${location}, destroying first`);
     destroyKawarp(location);
+    state = getKawarpState(location);
   }
 
   creationInProgress.add(location);

--- a/contents/lib/kawarpManager.ts
+++ b/contents/lib/kawarpManager.ts
@@ -56,6 +56,8 @@ const SPEED_LERP_UP = 0.05;
 const SPEED_LERP_DOWN = 0.03;
 const SPEED_THRESHOLD = 0.001;
 
+export const PIP_LOCATION = "pip";
+
 const loadImageSafely = async (instance: Kawarp, url: string): Promise<void> => {
   try {
     await instance.loadImage(url);
@@ -618,7 +620,7 @@ export const updateKawarpSettings = (
     }
 
     // If container was removed from DOM, clean up state
-    if (!document.contains(state.container)) {
+    if (!state.container.ownerDocument.contains(state.container)) {
       logger.log(`Container for ${loc} was removed from DOM, cleaning up state`);
       destroyKawarp(loc);
       return;
@@ -659,12 +661,14 @@ export const updateKawarpSettings = (
 export const hasKawarp = (location?: string): boolean => {
   if (location) {
     const state = getKawarpState(location);
-    return state.instance !== null && state.container !== null && document.contains(state.container);
+    return (
+      state.instance !== null && state.container !== null && state.container.ownerDocument.contains(state.container)
+    );
   }
   return (
     kawarps.size > 0 &&
     Array.from(kawarps.values()).some(
-      s => s.instance !== null && s.container !== null && document.contains(s.container)
+      s => s.instance !== null && s.container !== null && s.container.ownerDocument.contains(s.container)
     )
   );
 };
@@ -725,4 +729,92 @@ export const resumeKawarp = (location?: string): void => {
       resumeForLocation(loc);
     }
   }
+};
+
+export const createPipKawarp = async (
+  pipWindow: Window,
+  settings: GradientSettings,
+  multipliers: DynamicMultipliers,
+  imageUrl: string | null
+): Promise<boolean> => {
+  if (creationInProgress.has(PIP_LOCATION)) return false;
+
+  let state = getKawarpState(PIP_LOCATION);
+  if (state.instance) {
+    destroyKawarp(PIP_LOCATION);
+    state = getKawarpState(PIP_LOCATION);
+  }
+
+  creationInProgress.add(PIP_LOCATION);
+
+  try {
+    const pipDocument = pipWindow.document;
+
+    state.container = pipDocument.createElement("div");
+    state.container.id = `better-lyrics-kawarp-${PIP_LOCATION}`;
+    state.container.style.cssText = `
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: -2;
+      opacity: 0;
+      will-change: opacity;
+      transition: opacity 0.5s ease-out;
+    `;
+
+    state.canvas = pipDocument.createElement("canvas");
+    state.canvas.style.cssText = "width: 100%; height: 100%; display: block;";
+    state.container.appendChild(state.canvas);
+    pipDocument.body.prepend(state.container);
+
+    const dynamicSpeed = settings.kawarpAnimationSpeed * multipliers.speedMultiplier;
+
+    state.instance = new Kawarp(state.canvas, {
+      warpIntensity: settings.kawarpWarpIntensity,
+      blurPasses: settings.kawarpBlurPasses,
+      animationSpeed: dynamicSpeed,
+      transitionDuration: settings.kawarpTransitionDuration,
+      saturation: settings.kawarpSaturation,
+      dithering: settings.kawarpDithering,
+      scale: 1,
+    });
+
+    state.currentSpeed = dynamicSpeed;
+    state.targetSpeed = dynamicSpeed;
+    state.lastSettings = { ...settings };
+    state.lastMultipliers = { ...multipliers };
+
+    if (imageUrl) {
+      try {
+        await loadImageSafely(state.instance, imageUrl);
+        state.currentImageUrl = imageUrl;
+      } catch (error) {
+        logger.error("Failed to load artwork for pip kawarp:", error);
+      }
+    }
+
+    state.instance.start();
+    state.container.style.opacity = settings.kawarpOpacity.toString();
+
+    logger.log("Mounted kawarp in the floating window");
+    return true;
+  } catch (error) {
+    logger.error("Failed to mount kawarp in the floating window:", error);
+    destroyKawarp(PIP_LOCATION);
+    return false;
+  } finally {
+    creationInProgress.delete(PIP_LOCATION);
+  }
+};
+
+export const setPipKawarpImage = async (imageUrl: string): Promise<void> => {
+  const state = getKawarpState(PIP_LOCATION);
+  if (!state.instance || imageUrl === state.currentImageUrl) return;
+
+  if (state.isTransitioning) {
+    state.pendingImageUrl = imageUrl;
+    return;
+  }
+
+  await processImageTransition(state, imageUrl, PIP_LOCATION);
 };

--- a/contents/lib/pipManager.ts
+++ b/contents/lib/pipManager.ts
@@ -117,6 +117,7 @@ const mount = async (): Promise<void> => {
   }
 
   isMounting = true;
+  let hasInstance = false;
   try {
     const shell = await waitForShell(pipWindow);
     if (!shell) {
@@ -130,13 +131,11 @@ const mount = async (): Promise<void> => {
     const settings = getSettings();
     const mounted = await kawarpManager.createPipKawarp(pipWindow, settings, getMultipliers(), readArtworkUrl(shell));
     if (!mounted) return;
+    hasInstance = true;
 
     // createPipKawarp awaits an image load, so the window can close inside it. sync() cannot catch
     // that: session is still null at this point, so it sees nothing to tear down.
-    if (window.documentPictureInPicture?.window !== pipWindow) {
-      kawarpManager.destroyKawarp(kawarpManager.PIP_LOCATION);
-      return;
-    }
+    if (window.documentPictureInPicture?.window !== pipWindow) return;
 
     const suppressionStyle = suppressBuiltInBackdrop(pipWindow);
 
@@ -151,6 +150,10 @@ const mount = async (): Promise<void> => {
     session = { window: pipWindow, shell, artObserver, suppressionStyle };
   } finally {
     isMounting = false;
+    // Every exit between creating the instance and recording the session leaves it unreachable:
+    // nothing else holds a handle, so teardown() and sync() have nothing to act on. Covers both
+    // the window closing mid-mount and anything below it throwing.
+    if (hasInstance && !session) kawarpManager.destroyKawarp(kawarpManager.PIP_LOCATION);
   }
 };
 

--- a/contents/lib/pipManager.ts
+++ b/contents/lib/pipManager.ts
@@ -1,0 +1,179 @@
+import type { DynamicMultipliers, GradientSettings } from "@/shared/constants/gradientSettings";
+import { logger } from "@/shared/utils/logger";
+import * as kawarpManager from "./kawarpManager";
+
+const PIP_OPEN_ATTRIBUTE = "blyrics-pip-open";
+const SHELL_SELECTOR = ".blyrics-pip-shell";
+const ART_PROPERTY = "--blyrics-pip-art";
+const BACKDROP_SELECTOR = ".blyrics-pip-backdrop";
+const SUPPRESSION_STYLE_ID = "better-lyrics-shaders-backdrop-suppression";
+const SHELL_TIMEOUT_MS = 5000;
+
+// Gecko hands a content script a cross-origin wrapper on the Picture-in-Picture window, so nothing
+// in this world can script it. Fixed in Firefox 154 (bugzilla 2045666 and 2053139), but 153 is the
+// current release, so every shipping Firefox lands here. `wrappedJSObject` is the Xray marker that
+// identifies the restricted sandbox, and is the same check Better Lyrics uses to decide whether to
+// delegate its own window to the page world.
+//
+// This is checked once and up front rather than left to the try/catch in createPipKawarp, because
+// that path would throw and log on every song change for the lifetime of the tab.
+const isRestrictedSandbox = "wrappedJSObject" in window;
+
+interface PipSession {
+  window: Window;
+  shell: HTMLElement;
+  artObserver: MutationObserver;
+  suppressionStyle: HTMLStyleElement;
+}
+
+// Better Lyrics paints its own blurred album-art wash. Kawarp replaces it rather than stacking
+// under it. Suppressed from this side rather than through a hook in Better Lyrics: shaders already
+// depends on that window's shell class and art custom property, so one more selector is the same
+// coupling, and doing it here works against every version that has shipped the window.
+const suppressBuiltInBackdrop = (pipWindow: Window): HTMLStyleElement => {
+  const style = pipWindow.document.createElement("style");
+  style.id = SUPPRESSION_STYLE_ID;
+  style.textContent = `${BACKDROP_SELECTOR} { opacity: 0 !important; }`;
+  pipWindow.document.head.appendChild(style);
+
+  if (!pipWindow.document.querySelector(BACKDROP_SELECTOR)) {
+    logger.log(`No ${BACKDROP_SELECTOR} found; Better Lyrics may have renamed it`);
+  }
+
+  return style;
+};
+
+let session: PipSession | null = null;
+let openObserver: MutationObserver | null = null;
+let isMounting = false;
+let getSettings: (() => GradientSettings) | null = null;
+let getMultipliers: (() => DynamicMultipliers) | null = null;
+
+const readArtworkUrl = (shell: HTMLElement): string | null => {
+  const raw = shell.style.getPropertyValue(ART_PROPERTY).trim();
+  const match = raw.match(/^url\(["']?(.+?)["']?\)$/);
+  return match ? match[1] : null;
+};
+
+// Better Lyrics sets blyrics-pip-open before it runs body.replaceChildren(shell), so anything
+// mounted on the attribute alone gets discarded. Wait for the shell itself.
+const waitForShell = (pipWindow: Window): Promise<HTMLElement | null> =>
+  new Promise(resolve => {
+    const existing = pipWindow.document.querySelector<HTMLElement>(SHELL_SELECTOR);
+    if (existing) {
+      resolve(existing);
+      return;
+    }
+
+    // Deliberately the opener's timer, not pipWindow's. A closing Picture-in-Picture window
+    // discards its pending timers along with its document, so a timeout scheduled there would
+    // never fire and this promise would never settle, wedging the caller's mounting guard.
+    const timeout = window.setTimeout(() => {
+      observer.disconnect();
+      resolve(null);
+    }, SHELL_TIMEOUT_MS);
+
+    const observer = new MutationObserver(() => {
+      const shell = pipWindow.document.querySelector<HTMLElement>(SHELL_SELECTOR);
+      if (!shell) return;
+      window.clearTimeout(timeout);
+      observer.disconnect();
+      resolve(shell);
+    });
+
+    observer.observe(pipWindow.document.body, { childList: true, subtree: true });
+  });
+
+// A closed window's pagehide can arrive after its successor has already opened, so only the window
+// that owns the current session may tear it down. Better Lyrics hit the same ordering (pipHost.ts).
+const teardown = (owner?: Window): void => {
+  if (!session || (owner && session.window !== owner)) return;
+  logger.log("Tearing down the floating window effect");
+
+  session.artObserver.disconnect();
+  session.suppressionStyle.remove();
+  kawarpManager.destroyKawarp(kawarpManager.PIP_LOCATION);
+  session = null;
+};
+
+// `session` is only assigned after two awaits, so it cannot guard against a second entry on its own.
+const mount = async (): Promise<void> => {
+  if (session || isMounting || !getSettings || !getMultipliers) return;
+
+  const pipWindow = window.documentPictureInPicture?.window;
+  if (!pipWindow) return;
+
+  isMounting = true;
+  try {
+    const shell = await waitForShell(pipWindow);
+    if (!shell) {
+      logger.log("Floating window shell never appeared, skipping");
+      return;
+    }
+
+    // The window can close, or be replaced, while waitForShell is pending.
+    if (window.documentPictureInPicture?.window !== pipWindow) return;
+
+    const settings = getSettings();
+    const mounted = await kawarpManager.createPipKawarp(pipWindow, settings, getMultipliers(), readArtworkUrl(shell));
+    if (!mounted) return;
+
+    // createPipKawarp awaits an image load, so the window can close inside it. sync() cannot catch
+    // that: session is still null at this point, so it sees nothing to tear down.
+    if (window.documentPictureInPicture?.window !== pipWindow) {
+      kawarpManager.destroyKawarp(kawarpManager.PIP_LOCATION);
+      return;
+    }
+
+    const suppressionStyle = suppressBuiltInBackdrop(pipWindow);
+
+    const artObserver = new MutationObserver(() => {
+      const url = readArtworkUrl(shell);
+      if (url) void kawarpManager.setPipKawarpImage(url);
+    });
+    artObserver.observe(shell, { attributes: true, attributeFilter: ["style"] });
+
+    pipWindow.addEventListener("pagehide", () => teardown(pipWindow), { once: true });
+
+    session = { window: pipWindow, shell, artObserver, suppressionStyle };
+  } finally {
+    isMounting = false;
+  }
+};
+
+// Exported because the popup can toggle `enabled` while the window is already open, and no attribute
+// changes when it does.
+export const sync = (): void => {
+  const shouldRun = document.documentElement.hasAttribute(PIP_OPEN_ATTRIBUTE) && getSettings?.().enabled === true;
+  if (shouldRun && !session) void mount();
+  else if (!shouldRun && session) teardown();
+};
+
+export const initialize = (dependencies: {
+  getSettings: () => GradientSettings;
+  getMultipliers: () => DynamicMultipliers;
+}): void => {
+  if (isRestrictedSandbox) {
+    logger.log("This browser does not let a content script reach the floating window, skipping");
+    return;
+  }
+
+  getSettings = dependencies.getSettings;
+  getMultipliers = dependencies.getMultipliers;
+
+  openObserver?.disconnect();
+  openObserver = new MutationObserver(sync);
+  openObserver.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: [PIP_OPEN_ATTRIBUTE],
+  });
+
+  // Better Lyrics can auto-restore the window before shaders finishes initializing.
+  sync();
+};
+
+export const cleanup = (): void => {
+  openObserver?.disconnect();
+  openObserver = null;
+  teardown();
+};

--- a/contents/lib/pipManager.ts
+++ b/contents/lib/pipManager.ts
@@ -53,6 +53,7 @@ const suppressBuiltInBackdrop = (pipWindow: Window): HTMLStyleElement => {
 let session: PipSession | null = null;
 let openObserver: MutationObserver | null = null;
 let isMounting = false;
+let isSyncPending = false;
 let getSettings: (() => GradientSettings) | null = null;
 let getMultipliers: (() => DynamicMultipliers) | null = null;
 
@@ -103,6 +104,17 @@ const teardown = (owner?: Window): void => {
   session = null;
 };
 
+const isPipEffectWanted = (): boolean =>
+  document.documentElement.hasAttribute(PIP_OPEN_ATTRIBUTE) && getSettings?.().enabled === true;
+
+// Identity is not liveness. For roughly 50ms after close, documentPictureInPicture.window still
+// hands back the same dead window, while `closed` flips synchronously. Without the `closed` term a
+// mount can finish against a window whose pagehide has already fired, leaving `session` bound to a
+// window that can never tear itself down. Keep this call adjacent to the pagehide registration
+// below: the stretch between them must stay synchronous for that guarantee to hold.
+const canFinishMount = (pipWindow: Window): boolean =>
+  !pipWindow.closed && window.documentPictureInPicture?.window === pipWindow && isPipEffectWanted();
+
 // `session` is only assigned after two awaits, so it cannot guard against a second entry on its own.
 const mount = async (): Promise<void> => {
   if (session || isMounting || isWindowUnreachable || !getSettings || !getMultipliers) return;
@@ -125,17 +137,14 @@ const mount = async (): Promise<void> => {
       return;
     }
 
-    // The window can close, or be replaced, while waitForShell is pending.
-    if (window.documentPictureInPicture?.window !== pipWindow) return;
+    if (!canFinishMount(pipWindow)) return;
 
     const settings = getSettings();
     const mounted = await kawarpManager.createPipKawarp(pipWindow, settings, getMultipliers(), readArtworkUrl(shell));
     if (!mounted) return;
     hasInstance = true;
 
-    // createPipKawarp awaits an image load, so the window can close inside it. sync() cannot catch
-    // that: session is still null at this point, so it sees nothing to tear down.
-    if (window.documentPictureInPicture?.window !== pipWindow) return;
+    if (!canFinishMount(pipWindow)) return;
 
     const suppressionStyle = suppressBuiltInBackdrop(pipWindow);
 
@@ -154,15 +163,30 @@ const mount = async (): Promise<void> => {
     // nothing else holds a handle, so teardown() and sync() have nothing to act on. Covers both
     // the window closing mid-mount and anything below it throwing.
     if (hasInstance && !session) kawarpManager.destroyKawarp(kawarpManager.PIP_LOCATION);
+
+    // Replayed last: a sync replayed before the cleanup above would start a mount whose still-null
+    // session makes `hasInstance && !session` destroy the state it is building. Clearing the flag
+    // first keeps a sync that lands during the replayed mount from being swallowed in turn.
+    if (isSyncPending) {
+      isSyncPending = false;
+      sync();
+    }
   }
 };
 
 // Exported because the popup can toggle `enabled` while the window is already open, and no attribute
 // changes when it does.
 export const sync = (): void => {
-  const shouldRun = document.documentElement.hasAttribute(PIP_OPEN_ATTRIBUTE) && getSettings?.().enabled === true;
-  if (shouldRun && !session) void mount();
-  else if (!shouldRun && session) teardown();
+  // A mount is a long await chain that cannot observe state changes, and it assigns `session` last,
+  // so a sync arriving mid-mount matches neither branch below. Record it and reconcile once it lands.
+  if (isMounting) {
+    isSyncPending = true;
+    return;
+  }
+
+  const isWanted = isPipEffectWanted();
+  if (isWanted && !session) void mount();
+  else if (!isWanted && session) teardown();
 };
 
 export const initialize = (dependencies: {
@@ -186,5 +210,7 @@ export const initialize = (dependencies: {
 export const cleanup = (): void => {
   openObserver?.disconnect();
   openObserver = null;
+  // Without this an in-flight mount's replay would remount right after an explicit teardown.
+  isSyncPending = false;
   teardown();
 };

--- a/contents/lib/pipManager.ts
+++ b/contents/lib/pipManager.ts
@@ -28,7 +28,6 @@ const canScript = (pipWindow: Window): boolean => {
 
 interface PipSession {
   window: Window;
-  shell: HTMLElement;
   artObserver: MutationObserver;
   suppressionStyle: HTMLStyleElement;
 }
@@ -156,7 +155,7 @@ const mount = async (): Promise<void> => {
 
     pipWindow.addEventListener("pagehide", () => teardown(pipWindow), { once: true });
 
-    session = { window: pipWindow, shell, artObserver, suppressionStyle };
+    session = { window: pipWindow, artObserver, suppressionStyle };
   } finally {
     isMounting = false;
     // Every exit between creating the instance and recording the session leaves it unreachable:

--- a/contents/lib/pipManager.ts
+++ b/contents/lib/pipManager.ts
@@ -9,15 +9,22 @@ const BACKDROP_SELECTOR = ".blyrics-pip-backdrop";
 const SUPPRESSION_STYLE_ID = "better-lyrics-shaders-backdrop-suppression";
 const SHELL_TIMEOUT_MS = 5000;
 
-// Gecko hands a content script a cross-origin wrapper on the Picture-in-Picture window, so nothing
-// in this world can script it. Fixed in Firefox 154 (bugzilla 2045666 and 2053139), but 153 is the
-// current release, so every shipping Firefox lands here. `wrappedJSObject` is the Xray marker that
-// identifies the restricted sandbox, and is the same check Better Lyrics uses to decide whether to
-// delegate its own window to the page world.
+// Some Gecko builds hand a content script a cross-origin wrapper on the Picture-in-Picture window,
+// where the first property access throws (bugzilla 2045666 and 2053139). Rather than infer that
+// from the browser or a version number, touch the window once and latch the answer: Firefox 153
+// scripts it fine from an MV2 content script, so a version gate would disable a path that works.
 //
-// This is checked once and up front rather than left to the try/catch in createPipKawarp, because
-// that path would throw and log on every song change for the lifetime of the tab.
-const isRestrictedSandbox = "wrappedJSObject" in window;
+// Latched rather than retried because the alternative is throwing and logging on every song change
+// for the lifetime of the tab.
+let isWindowUnreachable = false;
+
+const canScript = (pipWindow: Window): boolean => {
+  try {
+    return !!pipWindow.document.body;
+  } catch {
+    return false;
+  }
+};
 
 interface PipSession {
   window: Window;
@@ -98,10 +105,16 @@ const teardown = (owner?: Window): void => {
 
 // `session` is only assigned after two awaits, so it cannot guard against a second entry on its own.
 const mount = async (): Promise<void> => {
-  if (session || isMounting || !getSettings || !getMultipliers) return;
+  if (session || isMounting || isWindowUnreachable || !getSettings || !getMultipliers) return;
 
   const pipWindow = window.documentPictureInPicture?.window;
   if (!pipWindow) return;
+
+  if (!canScript(pipWindow)) {
+    isWindowUnreachable = true;
+    logger.log("This browser does not allow scripting the floating window, disabling the effect");
+    return;
+  }
 
   isMounting = true;
   try {
@@ -153,11 +166,6 @@ export const initialize = (dependencies: {
   getSettings: () => GradientSettings;
   getMultipliers: () => DynamicMultipliers;
 }): void => {
-  if (isRestrictedSandbox) {
-    logger.log("This browser does not let a content script reach the floating window, skipping");
-    return;
-  }
-
   getSettings = dependencies.getSettings;
   getMultipliers = dependencies.getMultipliers;
 

--- a/contents/youtube-music.ts
+++ b/contents/youtube-music.ts
@@ -6,6 +6,7 @@ import * as gradientController from "./lib/gradientController";
 import * as kawarpManager from "./lib/kawarpManager";
 import * as messageHandler from "./lib/messageHandler";
 import * as navigationManager from "./lib/navigationManager";
+import * as pipManager from "./lib/pipManager";
 
 export const config: PlasmoCSConfig = {
   matches: ["https://music.youtube.com/*"],
@@ -58,11 +59,17 @@ const initializeApp = async (): Promise<void> => {
     gradientController.startAudioIfEnabled();
 
     navigationManager.initialize(gradientController.checkAndUpdateGradient);
+
+    pipManager.initialize({
+      getSettings: gradientController.getSettings,
+      getMultipliers: gradientController.getDynamicMultipliers,
+    });
   }, 0);
 };
 
 const cleanup = (): void => {
   navigationManager.cleanup();
+  pipManager.cleanup();
   gradientController.cleanup();
 };
 

--- a/shared/types/documentPictureInPicture.d.ts
+++ b/shared/types/documentPictureInPicture.d.ts
@@ -1,0 +1,7 @@
+interface DocumentPictureInPicture {
+  readonly window: Window | null;
+}
+
+interface Window {
+  readonly documentPictureInPicture?: DocumentPictureInPicture;
+}


### PR DESCRIPTION
## Overview

Better Lyrics 2.4.0 ships a floating lyrics window that paints its own blurred album art behind the text. Swap in kawarp when shaders is installed. The window already publishes the artwork URL it resolved, so nothing needs plumbing across: find the window, mount a canvas, hide the built in wash with an injected style. Better Lyrics needs no changes.

Also fixes an older leak. Rebuilding an effect dropped its tracked state while the caller kept writing to it, so a live instance went unreachable and rendered forever, with a fresh one leaking on top on the next song change.
