### PR TITLE
feat: share one audio context with tacet

### DIFF
--- a/contents/audio-main-world.ts
+++ b/contents/audio-main-world.ts
@@ -1,0 +1,253 @@
+import type { PlasmoCSConfig } from "plasmo";
+import { logger } from "@/shared/utils/logger";
+import {
+  type AnalysisSettings,
+  isAudioCommand,
+  postAudioMessage,
+  publishSharedAudioBus,
+  readSharedAudioBus,
+  type SharedAudioBus,
+} from "./lib/audioBridge";
+
+// The Web Audio half of what contents/lib/audioAnalysis.ts used to do alone;
+// that module is now the isolated-world facade over this one.
+
+export const config: PlasmoCSConfig = {
+  matches: ["https://music.youtube.com/*"],
+  all_frames: false,
+  world: "MAIN",
+};
+
+const ANALYSIS_INTERVAL = 100;
+const MIN_VOLUME_FOR_ANALYSIS = 0.005;
+const INIT_RETRY_MS = 1000;
+const ANALYSER_FFT_SIZE = 1024;
+const ANALYSER_SMOOTHING = 0.8;
+
+interface GraphState {
+  context: AudioContext | null;
+  analyser: AnalyserNode | null;
+  source: MediaElementAudioSourceNode | null;
+  element: HTMLMediaElement | null;
+  dataArray: Uint8Array<ArrayBuffer> | null;
+  rafId: number | null;
+  initTimeoutId: number | null;
+  resumeContextHandler: (() => Promise<void>) | null;
+  settings: AnalysisSettings | null;
+  isInitialized: boolean;
+  lastAnalysisTime: number;
+}
+
+const state: GraphState = {
+  context: null,
+  analyser: null,
+  source: null,
+  element: null,
+  dataArray: null,
+  rafId: null,
+  initTimeoutId: null,
+  resumeContextHandler: null,
+  settings: null,
+  isInitialized: false,
+  lastAnalysisTime: 0,
+};
+
+const claimedElements = new WeakSet<HTMLMediaElement>();
+
+const currentElement = (): HTMLMediaElement | null => document.querySelector("audio, video");
+
+const attachResumeOnGesture = (context: AudioContext): void => {
+  if (context.state !== "suspended") return;
+
+  if (state.resumeContextHandler) {
+    document.removeEventListener("click", state.resumeContextHandler);
+    document.removeEventListener("keydown", state.resumeContextHandler);
+  }
+
+  state.resumeContextHandler = async () => {
+    if (state.context && state.context.state === "suspended") {
+      await state.context.resume();
+    }
+    if (state.resumeContextHandler) {
+      document.removeEventListener("click", state.resumeContextHandler);
+      document.removeEventListener("keydown", state.resumeContextHandler);
+      state.resumeContextHandler = null;
+    }
+  };
+
+  document.addEventListener("click", state.resumeContextHandler);
+  document.addEventListener("keydown", state.resumeContextHandler);
+};
+
+const buildAnalyser = (context: AudioContext, source: MediaElementAudioSourceNode): void => {
+  state.analyser?.disconnect();
+  state.analyser = context.createAnalyser();
+  state.analyser.fftSize = ANALYSER_FFT_SIZE;
+  state.analyser.smoothingTimeConstant = ANALYSER_SMOOTHING;
+  state.dataArray = new Uint8Array(new ArrayBuffer(state.analyser.frequencyBinCount));
+  source.connect(state.analyser);
+};
+
+const acquireBus = (element: HTMLMediaElement): SharedAudioBus | null => {
+  const shared = readSharedAudioBus();
+  if (shared && shared.element === element) {
+    logger.log("Audio analysis attached to an existing shared bus");
+    return shared;
+  }
+
+  if (claimedElements.has(element)) {
+    logger.error("This element was already claimed and can never be routed again. Reload the page.");
+    return null;
+  }
+
+  const context = new AudioContext();
+  attachResumeOnGesture(context);
+
+  let source: MediaElementAudioSourceNode;
+  try {
+    source = context.createMediaElementSource(element);
+  } catch (error) {
+    claimedElements.add(element);
+    logger.error("Could not capture the audio element, effects will not react to sound:", error);
+    void context.close();
+    return null;
+  }
+  claimedElements.add(element);
+
+  // Only the owner routes to the destination; reusing a bus and connecting again
+  // would play the original twice.
+  source.connect(context.destination);
+
+  const bus: SharedAudioBus = { version: 1, context, source, element };
+  publishSharedAudioBus(bus);
+  return bus;
+};
+
+const bindTo = (element: HTMLMediaElement): boolean => {
+  const bus = acquireBus(element);
+  if (!bus) return false;
+
+  state.context = bus.context;
+  state.source = bus.source;
+  state.element = element;
+  buildAnalyser(bus.context, bus.source);
+  return true;
+};
+
+const initialize = (): void => {
+  if (state.isInitialized) return;
+
+  try {
+    const element = currentElement();
+    if (!element) {
+      state.initTimeoutId = window.setTimeout(initialize, INIT_RETRY_MS);
+      return;
+    }
+    state.initTimeoutId = null;
+
+    if (!bindTo(element)) return;
+
+    state.isInitialized = true;
+    postAudioMessage({ type: "bls-audio-initialized" });
+    logger.log("Audio analysis initialized (passthrough mode)");
+  } catch (error) {
+    logger.error("Error initializing audio analysis:", error);
+  }
+};
+
+const analyzeAudioFrame = (timestamp: number): void => {
+  const settings = state.settings;
+  if (!state.analyser || !state.dataArray || !state.element || !settings) {
+    state.rafId = null;
+    return;
+  }
+
+  if (timestamp - state.lastAnalysisTime >= ANALYSIS_INTERVAL) {
+    state.analyser.getByteTimeDomainData(state.dataArray);
+
+    const currentVolume = state.element.volume;
+    const volumeMultiplier = currentVolume > MIN_VOLUME_FOR_ANALYSIS ? 1 / currentVolume : 1;
+
+    let peak = 0;
+    const length = state.dataArray.length;
+    const threshold = settings.audioBeatThreshold;
+
+    for (let i = 0; i < length; i++) {
+      const rawAmplitude = Math.abs(state.dataArray[i] - 128) / 128;
+      const amplitude = rawAmplitude * volumeMultiplier;
+      if (amplitude > peak) {
+        peak = amplitude;
+        if (peak > threshold) break;
+      }
+    }
+
+    const isBeat = peak > threshold;
+    const scaleBoost = settings.kawarpAudioScaleBoost;
+
+    postAudioMessage({
+      type: "bls-audio-beat",
+      speedMultiplier: settings.audioResponsive && isBeat ? settings.audioSpeedMultiplier : 1,
+      scaleMultiplier: settings.audioResponsive && isBeat ? 1 + scaleBoost / 100 : 1,
+    });
+
+    state.lastAnalysisTime = timestamp;
+  }
+
+  state.rafId = requestAnimationFrame(analyzeAudioFrame);
+};
+
+const startAnalysis = (settings: AnalysisSettings): void => {
+  state.settings = settings;
+  if (state.rafId !== null) cancelAnimationFrame(state.rafId);
+  state.lastAnalysisTime = 0;
+  state.rafId = requestAnimationFrame(analyzeAudioFrame);
+};
+
+const stopAnalysis = (): void => {
+  if (state.rafId !== null) {
+    cancelAnimationFrame(state.rafId);
+    state.rafId = null;
+  }
+  if (state.initTimeoutId !== null) {
+    clearTimeout(state.initTimeoutId);
+    state.initTimeoutId = null;
+  }
+  state.lastAnalysisTime = 0;
+};
+
+const reconnect = (): void => {
+  if (!state.isInitialized) return;
+
+  const element = currentElement();
+  if (!element) return;
+
+  const elementChanged = element !== state.element;
+  const boundElementDetached = state.element !== null && !document.contains(state.element);
+  if (!elementChanged && !boundElementDetached) return;
+
+  logger.log("Audio element changed, reconnecting...");
+  bindTo(element);
+};
+
+window.addEventListener("message", event => {
+  if (event.source !== window || event.origin !== window.location.origin) return;
+  const data: unknown = event.data;
+  if (!isAudioCommand(data)) return;
+
+  switch (data.type) {
+    case "bls-audio-initialize":
+      logger.setEnabled(data.showLogs);
+      initialize();
+      break;
+    case "bls-audio-start":
+      logger.setEnabled(data.showLogs);
+      startAnalysis(data.settings);
+      break;
+    case "bls-audio-stop":
+      stopAnalysis();
+      break;
+    case "bls-audio-reconnect":
+      reconnect();
+      break;
+  }
+});

--- a/contents/inject-main-world.ts
+++ b/contents/inject-main-world.ts
@@ -14,9 +14,8 @@ function injectScript(fileName: string): void {
   (document.head || document.documentElement).appendChild(script);
 }
 
-// A url: import resolves against the page rather than the extension, so only
-// the hashed filename survives the trip. Plasmo adds that same hashed name to
-// web_accessible_resources on our behalf.
+// A url: import resolves against the page, so only the hashed filename is usable
+// here. Plasmo adds that name to web_accessible_resources itself.
 function injectBundle(bundleUrl: string): void {
   const fileName = bundleUrl.split("/").pop()?.split("?")[0];
   if (fileName) injectScript(fileName);

--- a/contents/inject-main-world.ts
+++ b/contents/inject-main-world.ts
@@ -1,4 +1,5 @@
 import type { PlasmoCSConfig } from "plasmo";
+import audioGraphBundleUrl from "url:./lib/audioGraph";
 
 export const config: PlasmoCSConfig = {
   matches: ["https://music.youtube.com/*"],
@@ -13,7 +14,16 @@ function injectScript(fileName: string): void {
   (document.head || document.documentElement).appendChild(script);
 }
 
+// A url: import resolves against the page rather than the extension, so only
+// the hashed filename survives the trip. Plasmo adds that same hashed name to
+// web_accessible_resources on our behalf.
+function injectBundle(bundleUrl: string): void {
+  const fileName = bundleUrl.split("/").pop()?.split("?")[0];
+  if (fileName) injectScript(fileName);
+}
+
 injectScript("assets/earlyInject.js");
+injectBundle(audioGraphBundleUrl);
 
 window.addEventListener("DOMContentLoaded", () => {
   injectScript("assets/playerScript.js");

--- a/contents/inject-main-world.ts
+++ b/contents/inject-main-world.ts
@@ -14,10 +14,12 @@ function injectScript(fileName: string): void {
   (document.head || document.documentElement).appendChild(script);
 }
 
-// A url: import resolves against the page, so only the hashed filename is usable
-// here. Plasmo adds that name to web_accessible_resources itself.
-function injectBundle(bundleUrl: string): void {
-  const fileName = bundleUrl.split("/").pop()?.split("?")[0];
+function extensionRelativeName(pageRelativeBundleUrl: string): string | undefined {
+  return pageRelativeBundleUrl.split("/").pop()?.split("?")[0];
+}
+
+function injectBundle(pageRelativeBundleUrl: string): void {
+  const fileName = extensionRelativeName(pageRelativeBundleUrl);
   if (fileName) injectScript(fileName);
 }
 

--- a/contents/lib/animatedArtManager.ts
+++ b/contents/lib/animatedArtManager.ts
@@ -1,9 +1,9 @@
 import { Storage } from "@plasmohq/storage";
 import browser from "webextension-polyfill";
+import { ANIMATED_ART_VIDEO_ID } from "@/shared/constants/mediaElements";
 import { logger } from "@/shared/utils/logger";
 
 const API_ENDPOINT = "https://artwork.boidu.dev";
-const VIDEO_ELEMENT_ID = "bls-video";
 const NOT_FOUND_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 const ALLOWED_VIDEO_HOSTS = new Set(["mvod.itunes.apple.com"]);
 
@@ -331,7 +331,7 @@ async function fetchArtworkUrl(
 
 function createVideoElement(videoUrl: string): HTMLVideoElement {
   const video = document.createElement("video");
-  video.id = VIDEO_ELEMENT_ID;
+  video.id = ANIMATED_ART_VIDEO_ID;
   video.muted = true;
   video.autoplay = true;
   video.loop = true;
@@ -363,7 +363,7 @@ function injectAnimatedArt(videoUrl: string): void {
     return;
   }
 
-  const existingVideo = thumbnail.querySelector(`#${VIDEO_ELEMENT_ID}`);
+  const existingVideo = thumbnail.querySelector(`#${ANIMATED_ART_VIDEO_ID}`);
   if (existingVideo) {
     existingVideo.remove();
   }
@@ -376,7 +376,7 @@ function injectAnimatedArt(videoUrl: string): void {
 }
 
 function getVideoElement(): HTMLVideoElement | null {
-  return document.querySelector(`#${VIDEO_ELEMENT_ID}`);
+  return document.querySelector(`#${ANIMATED_ART_VIDEO_ID}`);
 }
 
 function removeAnimatedArt(): void {

--- a/contents/lib/audioAnalysis.ts
+++ b/contents/lib/audioAnalysis.ts
@@ -1,8 +1,8 @@
 import type { DynamicMultipliers, GradientSettings } from "@/shared/constants/gradientSettings";
 import { isAudioResult, postAudioMessage } from "./audioBridge";
 
-// The Web Audio graph lives in contents/lib/audioGraph.ts; this drives it and
-// keeps the element listeners, which need no AudioContext and so stay here.
+// Drives the page-world graph in audioGraph.ts. The element listeners need no
+// AudioContext, so they stay on this side.
 
 interface FacadeState {
   element: HTMLMediaElement | null;
@@ -96,9 +96,7 @@ window.addEventListener("message", event => {
   const data: unknown = event.data;
   if (!isAudioResult(data)) return;
 
-  // The graph announces itself on load because these two scripts race: whichever
-  // loses would otherwise post into a window nobody is listening on yet, and a
-  // dropped initialize leaves the effects unreactive until a reload.
+  // The two scripts race, and a loser posts into a window nobody is listening on.
   if (data.type === "bls-audio-ready") {
     if (state.pendingInitialize) postInitialize(state.pendingInitialize.showLogs);
     return;
@@ -107,8 +105,7 @@ window.addEventListener("message", event => {
   if (data.type === "bls-audio-initialized") {
     state.isInitialized = true;
     state.pendingInitialize = null;
-    // The graph is claimed a round trip after the caller asked, so a start
-    // issued against the old synchronous flag would otherwise be dropped.
+    // A start issued before the claim landed would otherwise be dropped.
     if (state.pendingStart) postStart(state.pendingStart.settings);
     return;
   }

--- a/contents/lib/audioAnalysis.ts
+++ b/contents/lib/audioAnalysis.ts
@@ -131,6 +131,7 @@ export const startAudioAnalysis = (
 
 export const stopAudioAnalysis = (): void => {
   state.pendingStart = null;
+  state.onBeatDetected = null;
   postAudioMessage({ type: "bls-audio-stop" });
 };
 

--- a/contents/lib/audioAnalysis.ts
+++ b/contents/lib/audioAnalysis.ts
@@ -1,9 +1,6 @@
 import type { DynamicMultipliers, GradientSettings } from "@/shared/constants/gradientSettings";
 import { isAudioResult, postAudioMessage } from "./audioBridge";
 
-// Drives the page-world graph in audioGraph.ts. The element listeners need no
-// AudioContext, so they stay on this side.
-
 interface FacadeState {
   element: HTMLMediaElement | null;
   isInitialized: boolean;
@@ -96,7 +93,6 @@ window.addEventListener("message", event => {
   const data: unknown = event.data;
   if (!isAudioResult(data)) return;
 
-  // The two scripts race, and a loser posts into a window nobody is listening on.
   if (data.type === "bls-audio-ready") {
     if (state.pendingInitialize) postInitialize(state.pendingInitialize.showLogs);
     return;
@@ -105,7 +101,6 @@ window.addEventListener("message", event => {
   if (data.type === "bls-audio-initialized") {
     state.isInitialized = true;
     state.pendingInitialize = null;
-    // A start issued before the claim landed would otherwise be dropped.
     if (state.pendingStart) postStart(state.pendingStart.settings);
     return;
   }

--- a/contents/lib/audioAnalysis.ts
+++ b/contents/lib/audioAnalysis.ts
@@ -1,46 +1,51 @@
 import type { DynamicMultipliers, GradientSettings } from "@/shared/constants/gradientSettings";
-import { logger } from "@/shared/utils/logger";
+import { isAudioResult, postAudioMessage } from "./audioBridge";
 
-interface AudioAnalysisState {
-  context: AudioContext | null;
-  analyser: AnalyserNode | null;
-  source: MediaElementAudioSourceNode | null;
+// The Web Audio graph lives in contents/audio-main-world.ts; this drives it and
+// keeps the element listeners, which need no AudioContext and so stay here.
+
+interface FacadeState {
   element: HTMLMediaElement | null;
-  rafId: number | null;
   isInitialized: boolean;
-  dataArray: Uint8Array<ArrayBuffer> | null;
-  lastAnalysisTime: number;
-  initTimeoutId: number | null;
-  resumeContextHandler: (() => Promise<void>) | null;
   playHandler: (() => void) | null;
   pauseHandler: (() => void) | null;
   onPlaybackStateChange: ((isPlaying: boolean) => void) | null;
+  onBeatDetected: ((multipliers: DynamicMultipliers) => void) | null;
+  elementPollId: number | null;
+  pendingStart: { settings: GradientSettings } | null;
 }
 
-const connectedElements = new WeakSet<HTMLMediaElement>();
-
-const state: AudioAnalysisState = {
-  context: null,
-  analyser: null,
-  source: null,
+const state: FacadeState = {
   element: null,
-  rafId: null,
   isInitialized: false,
-  dataArray: null,
-  lastAnalysisTime: 0,
-  initTimeoutId: null,
-  resumeContextHandler: null,
   playHandler: null,
   pauseHandler: null,
   onPlaybackStateChange: null,
+  onBeatDetected: null,
+  elementPollId: null,
+  pendingStart: null,
 };
 
-const ANALYSIS_INTERVAL = 100;
-const MIN_VOLUME_FOR_ANALYSIS = 0.005;
+const ELEMENT_POLL_MS = 1000;
 
 const reusableMultipliers: DynamicMultipliers = {
   speedMultiplier: 1,
   scaleMultiplier: 1,
+};
+
+const currentElement = (): HTMLMediaElement | null => document.querySelector("audio, video");
+
+const postStart = (settings: GradientSettings): void => {
+  postAudioMessage({
+    type: "bls-audio-start",
+    showLogs: settings.showLogs,
+    settings: {
+      audioResponsive: settings.audioResponsive,
+      audioBeatThreshold: settings.audioBeatThreshold,
+      audioSpeedMultiplier: settings.audioSpeedMultiplier,
+      kawarpAudioScaleBoost: settings.kawarpAudioScaleBoost,
+    },
+  });
 };
 
 const removeElementListeners = (element: HTMLMediaElement): void => {
@@ -54,195 +59,74 @@ const removeElementListeners = (element: HTMLMediaElement): void => {
 
 const addElementListeners = (element: HTMLMediaElement): void => {
   state.playHandler = () => {
-    if (state.onPlaybackStateChange) {
-      state.onPlaybackStateChange(true);
-    }
+    state.onPlaybackStateChange?.(true);
   };
   state.pauseHandler = () => {
-    if (state.onPlaybackStateChange) {
-      state.onPlaybackStateChange(false);
-    }
+    state.onPlaybackStateChange?.(false);
   };
   element.addEventListener("play", state.playHandler);
   element.addEventListener("pause", state.pauseHandler);
 };
 
-export const initializeAudioAnalysis = async (): Promise<void> => {
-  if (state.isInitialized) {
-    return;
-  }
-
-  try {
-    state.element = document.querySelector("audio, video") as HTMLMediaElement;
-    if (!state.element) {
-      state.initTimeoutId = window.setTimeout(initializeAudioAnalysis, 1000);
-      return;
-    }
-    state.initTimeoutId = null;
-
-    state.context = new (window.AudioContext || (window as any).webkitAudioContext)();
-
-    if (state.context.state === "suspended") {
-      if (state.resumeContextHandler) {
-        document.removeEventListener("click", state.resumeContextHandler);
-        document.removeEventListener("keydown", state.resumeContextHandler);
-      }
-
-      state.resumeContextHandler = async () => {
-        if (state.context && state.context.state === "suspended") {
-          await state.context.resume();
-        }
-        if (state.resumeContextHandler) {
-          document.removeEventListener("click", state.resumeContextHandler);
-          document.removeEventListener("keydown", state.resumeContextHandler);
-          state.resumeContextHandler = null;
-        }
-      };
-
-      document.addEventListener("click", state.resumeContextHandler);
-      document.addEventListener("keydown", state.resumeContextHandler);
-    }
-
-    state.analyser = state.context.createAnalyser();
-    state.analyser.fftSize = 1024;
-    state.analyser.smoothingTimeConstant = 0.8;
-
-    const bufferLength = state.analyser.frequencyBinCount;
-    state.dataArray = new Uint8Array(new ArrayBuffer(bufferLength));
-
-    state.source = state.context.createMediaElementSource(state.element);
-    state.source.connect(state.analyser);
-    state.source.connect(state.context.destination);
-
-    connectedElements.add(state.element);
-
-    addElementListeners(state.element);
-
-    state.isInitialized = true;
-    logger.log("Audio analysis initialized (passthrough mode)");
-  } catch (error) {
-    logger.error("Error initializing audio analysis:", error);
-  }
+const bindListenersTo = (element: HTMLMediaElement): void => {
+  if (element === state.element) return;
+  if (state.element) removeElementListeners(state.element);
+  state.element = element;
+  addElementListeners(element);
 };
 
-const analyzeAudioFrame = (
-  settings: GradientSettings,
-  onBeatDetected: (multipliers: DynamicMultipliers) => void,
-  timestamp: number
-): void => {
-  if (!state.analyser || !state.dataArray || !state.element) {
-    state.rafId = null;
+const trackElement = (): void => {
+  const element = currentElement();
+  if (element) bindListenersTo(element);
+  if (state.elementPollId !== null || state.element) return;
+  state.elementPollId = window.setTimeout(() => {
+    state.elementPollId = null;
+    trackElement();
+  }, ELEMENT_POLL_MS);
+};
+
+window.addEventListener("message", event => {
+  if (event.source !== window || event.origin !== window.location.origin) return;
+  const data: unknown = event.data;
+  if (!isAudioResult(data)) return;
+
+  if (data.type === "bls-audio-initialized") {
+    state.isInitialized = true;
+    // The graph is claimed a round trip after the caller asked, so a start
+    // issued against the old synchronous flag would otherwise be dropped.
+    if (state.pendingStart) postStart(state.pendingStart.settings);
     return;
   }
 
-  if (timestamp - state.lastAnalysisTime >= ANALYSIS_INTERVAL) {
-    state.analyser.getByteTimeDomainData(state.dataArray);
+  reusableMultipliers.speedMultiplier = data.speedMultiplier;
+  reusableMultipliers.scaleMultiplier = data.scaleMultiplier;
+  state.onBeatDetected?.(reusableMultipliers);
+});
 
-    const currentVolume = state.element.volume;
-    const volumeMultiplier = currentVolume > MIN_VOLUME_FOR_ANALYSIS ? 1 / currentVolume : 1;
-
-    let peak = 0;
-    const length = state.dataArray.length;
-    const threshold = settings.audioBeatThreshold;
-
-    for (let i = 0; i < length; i++) {
-      const rawAmplitude = Math.abs(state.dataArray[i] - 128) / 128;
-      const amplitude = rawAmplitude * volumeMultiplier;
-      if (amplitude > peak) {
-        peak = amplitude;
-        if (peak > threshold) break;
-      }
-    }
-
-    const isBeat = peak > threshold;
-
-    const scaleBoost = settings.kawarpAudioScaleBoost;
-
-    reusableMultipliers.speedMultiplier = settings.audioResponsive && isBeat ? settings.audioSpeedMultiplier : 1;
-    reusableMultipliers.scaleMultiplier = settings.audioResponsive && isBeat ? 1 + scaleBoost / 100 : 1;
-
-    onBeatDetected(reusableMultipliers);
-
-    state.lastAnalysisTime = timestamp;
-  }
-
-  state.rafId = requestAnimationFrame(ts => analyzeAudioFrame(settings, onBeatDetected, ts));
+export const initializeAudioAnalysis = async (showLogs = true): Promise<void> => {
+  trackElement();
+  postAudioMessage({ type: "bls-audio-initialize", showLogs });
 };
 
 export const startAudioAnalysis = (
   settings: GradientSettings,
   onBeatDetected: (multipliers: DynamicMultipliers) => void
 ): void => {
-  if (state.rafId !== null) {
-    cancelAnimationFrame(state.rafId);
-  }
-
-  state.lastAnalysisTime = 0;
-  state.rafId = requestAnimationFrame(timestamp => analyzeAudioFrame(settings, onBeatDetected, timestamp));
+  state.onBeatDetected = onBeatDetected;
+  state.pendingStart = { settings };
+  postStart(settings);
 };
 
 export const stopAudioAnalysis = (): void => {
-  if (state.rafId !== null) {
-    cancelAnimationFrame(state.rafId);
-    state.rafId = null;
-  }
-
-  if (state.initTimeoutId !== null) {
-    clearTimeout(state.initTimeoutId);
-    state.initTimeoutId = null;
-  }
-
-  state.lastAnalysisTime = 0;
-};
-
-const reconnectToNewElement = (newElement: HTMLMediaElement): void => {
-  if (!state.context) return;
-
-  if (state.element) {
-    removeElementListeners(state.element);
-  }
-
-  if (connectedElements.has(newElement)) {
-    logger.log("Element already has MediaElementSource, re-adding listeners");
-    state.element = newElement;
-    addElementListeners(newElement);
-    return;
-  }
-
-  state.analyser = state.context.createAnalyser();
-  state.analyser.fftSize = 1024;
-  state.analyser.smoothingTimeConstant = 0.8;
-
-  const bufferLength = state.analyser.frequencyBinCount;
-  state.dataArray = new Uint8Array(new ArrayBuffer(bufferLength));
-
-  state.source = state.context.createMediaElementSource(newElement);
-  state.source.connect(state.analyser);
-  state.source.connect(state.context.destination);
-
-  connectedElements.add(newElement);
-
-  state.element = newElement;
-
-  addElementListeners(newElement);
-
-  logger.log("Audio analysis reconnected to new element");
+  state.pendingStart = null;
+  postAudioMessage({ type: "bls-audio-stop" });
 };
 
 export const checkAndReconnectElement = (): void => {
   if (!state.isInitialized) return;
-
-  const currentElement = document.querySelector("audio, video") as HTMLMediaElement;
-
-  if (currentElement && currentElement !== state.element) {
-    logger.log("Audio element changed, reconnecting...");
-    reconnectToNewElement(currentElement);
-  } else if (state.element && !document.contains(state.element)) {
-    if (currentElement) {
-      logger.log("Old audio element detached, reconnecting to new one...");
-      reconnectToNewElement(currentElement);
-    }
-  }
+  const element = currentElement();
+  if (element) bindListenersTo(element);
+  postAudioMessage({ type: "bls-audio-reconnect" });
 };
 
 export const isAudioInitialized = (): boolean => state.isInitialized;
@@ -252,5 +136,6 @@ export const setPlaybackStateCallback = (callback: ((isPlaying: boolean) => void
 };
 
 export const isPlaying = (): boolean => {
-  return state.element ? !state.element.paused : false;
+  const element = state.element ?? currentElement();
+  return element ? !element.paused : false;
 };

--- a/contents/lib/audioAnalysis.ts
+++ b/contents/lib/audioAnalysis.ts
@@ -1,7 +1,7 @@
 import type { DynamicMultipliers, GradientSettings } from "@/shared/constants/gradientSettings";
 import { isAudioResult, postAudioMessage } from "./audioBridge";
 
-// The Web Audio graph lives in contents/audio-main-world.ts; this drives it and
+// The Web Audio graph lives in contents/lib/audioGraph.ts; this drives it and
 // keeps the element listeners, which need no AudioContext and so stay here.
 
 interface FacadeState {
@@ -13,6 +13,7 @@ interface FacadeState {
   onBeatDetected: ((multipliers: DynamicMultipliers) => void) | null;
   elementPollId: number | null;
   pendingStart: { settings: GradientSettings } | null;
+  pendingInitialize: { showLogs: boolean } | null;
 }
 
 const state: FacadeState = {
@@ -24,6 +25,7 @@ const state: FacadeState = {
   onBeatDetected: null,
   elementPollId: null,
   pendingStart: null,
+  pendingInitialize: null,
 };
 
 const ELEMENT_POLL_MS = 1000;
@@ -34,6 +36,10 @@ const reusableMultipliers: DynamicMultipliers = {
 };
 
 const currentElement = (): HTMLMediaElement | null => document.querySelector("audio, video");
+
+const postInitialize = (showLogs: boolean): void => {
+  postAudioMessage({ type: "bls-audio-initialize", showLogs });
+};
 
 const postStart = (settings: GradientSettings): void => {
   postAudioMessage({
@@ -90,8 +96,17 @@ window.addEventListener("message", event => {
   const data: unknown = event.data;
   if (!isAudioResult(data)) return;
 
+  // The graph announces itself on load because these two scripts race: whichever
+  // loses would otherwise post into a window nobody is listening on yet, and a
+  // dropped initialize leaves the effects unreactive until a reload.
+  if (data.type === "bls-audio-ready") {
+    if (state.pendingInitialize) postInitialize(state.pendingInitialize.showLogs);
+    return;
+  }
+
   if (data.type === "bls-audio-initialized") {
     state.isInitialized = true;
+    state.pendingInitialize = null;
     // The graph is claimed a round trip after the caller asked, so a start
     // issued against the old synchronous flag would otherwise be dropped.
     if (state.pendingStart) postStart(state.pendingStart.settings);
@@ -105,7 +120,8 @@ window.addEventListener("message", event => {
 
 export const initializeAudioAnalysis = async (showLogs = true): Promise<void> => {
   trackElement();
-  postAudioMessage({ type: "bls-audio-initialize", showLogs });
+  state.pendingInitialize = { showLogs };
+  postInitialize(showLogs);
 };
 
 export const startAudioAnalysis = (

--- a/contents/lib/audioAnalysis.ts
+++ b/contents/lib/audioAnalysis.ts
@@ -1,4 +1,5 @@
 import type { DynamicMultipliers, GradientSettings } from "@/shared/constants/gradientSettings";
+import { PLAYER_MEDIA_SELECTOR } from "@/shared/constants/mediaElements";
 import { isAudioResult, postAudioMessage } from "./audioBridge";
 
 interface FacadeState {
@@ -32,7 +33,7 @@ const reusableMultipliers: DynamicMultipliers = {
   scaleMultiplier: 1,
 };
 
-const currentElement = (): HTMLMediaElement | null => document.querySelector("audio, video");
+const currentElement = (): HTMLMediaElement | null => document.querySelector(PLAYER_MEDIA_SELECTOR);
 
 const postInitialize = (showLogs: boolean): void => {
   postAudioMessage({ type: "bls-audio-initialize", showLogs });
@@ -90,24 +91,27 @@ const trackElement = (): void => {
 
 window.addEventListener("message", event => {
   if (event.source !== window || event.origin !== window.location.origin) return;
-  const data: unknown = event.data;
-  if (!isAudioResult(data)) return;
+  const message: unknown = event.data;
+  if (!isAudioResult(message)) return;
 
-  if (data.type === "bls-audio-ready") {
-    if (state.pendingInitialize) postInitialize(state.pendingInitialize.showLogs);
-    return;
+  switch (message.type) {
+    case "bls-audio-ready":
+      if (state.pendingInitialize) postInitialize(state.pendingInitialize.showLogs);
+      break;
+    case "bls-audio-initialized": {
+      state.isInitialized = true;
+      state.pendingInitialize = null;
+      const pendingStart = state.pendingStart;
+      state.pendingStart = null;
+      if (pendingStart) postStart(pendingStart.settings);
+      break;
+    }
+    case "bls-audio-beat":
+      reusableMultipliers.speedMultiplier = message.speedMultiplier;
+      reusableMultipliers.scaleMultiplier = message.scaleMultiplier;
+      state.onBeatDetected?.(reusableMultipliers);
+      break;
   }
-
-  if (data.type === "bls-audio-initialized") {
-    state.isInitialized = true;
-    state.pendingInitialize = null;
-    if (state.pendingStart) postStart(state.pendingStart.settings);
-    return;
-  }
-
-  reusableMultipliers.speedMultiplier = data.speedMultiplier;
-  reusableMultipliers.scaleMultiplier = data.scaleMultiplier;
-  state.onBeatDetected?.(reusableMultipliers);
 });
 
 export const initializeAudioAnalysis = async (showLogs = true): Promise<void> => {

--- a/contents/lib/audioBridge.ts
+++ b/contents/lib/audioBridge.ts
@@ -1,0 +1,86 @@
+// An AudioContext and its MediaElementAudioSourceNode belong to the realm that
+// created them, and two extensions share no realm except the page's own, so the
+// graph lives in the page world and only plain data crosses. postMessage rather
+// than CustomEvent detail, which needs cloneInto under Gecko's Xrays.
+
+interface AnalysisSettings {
+  audioResponsive: boolean;
+  audioBeatThreshold: number;
+  audioSpeedMultiplier: number;
+  kawarpAudioScaleBoost: number;
+}
+
+type AudioCommand =
+  | { type: "bls-audio-initialize"; showLogs: boolean }
+  | { type: "bls-audio-start"; settings: AnalysisSettings; showLogs: boolean }
+  | { type: "bls-audio-stop" }
+  | { type: "bls-audio-reconnect" };
+
+type AudioResult =
+  | { type: "bls-audio-initialized" }
+  | { type: "bls-audio-beat"; speedMultiplier: number; scaleMultiplier: number };
+
+const AUDIO_COMMAND_TYPES: readonly string[] = [
+  "bls-audio-initialize",
+  "bls-audio-start",
+  "bls-audio-stop",
+  "bls-audio-reconnect",
+];
+
+const AUDIO_RESULT_TYPES: readonly string[] = ["bls-audio-initialized", "bls-audio-beat"];
+
+const messageType = (data: unknown): string | null => {
+  if (typeof data !== "object" || data === null) return null;
+  const type = (data as { type?: unknown }).type;
+  return typeof type === "string" ? type : null;
+};
+
+const isAudioCommand = (data: unknown): data is AudioCommand => {
+  const type = messageType(data);
+  return type !== null && AUDIO_COMMAND_TYPES.includes(type);
+};
+
+const isAudioResult = (data: unknown): data is AudioResult => {
+  const type = messageType(data);
+  return type !== null && AUDIO_RESULT_TYPES.includes(type);
+};
+
+const postAudioMessage = (message: AudioCommand | AudioResult): void => {
+  window.postMessage(message, window.location.origin);
+};
+
+// createMediaElementSource may be called once per element for the life of the
+// page. Whichever extension claims it first publishes here; the other reuses.
+const AUDIO_BUS_KEY = "__blyricsAudio";
+const AUDIO_BUS_VERSION = 1;
+
+interface SharedAudioBus {
+  version: number;
+  context: AudioContext;
+  source: MediaElementAudioSourceNode;
+  element: HTMLMediaElement;
+}
+
+const isSharedAudioBus = (value: unknown): value is SharedAudioBus => {
+  if (typeof value !== "object" || value === null) return false;
+  const bus = value as Record<string, unknown>;
+  return (
+    typeof bus.version === "number" &&
+    bus.context instanceof AudioContext &&
+    bus.source instanceof MediaElementAudioSourceNode &&
+    bus.element instanceof HTMLMediaElement
+  );
+};
+
+const readSharedAudioBus = (): SharedAudioBus | null => {
+  const existing = (window as unknown as Record<string, unknown>)[AUDIO_BUS_KEY];
+  if (!isSharedAudioBus(existing)) return null;
+  return existing.version === AUDIO_BUS_VERSION ? existing : null;
+};
+
+const publishSharedAudioBus = (bus: SharedAudioBus): void => {
+  (window as unknown as Record<string, unknown>)[AUDIO_BUS_KEY] = bus;
+};
+
+export { isAudioCommand, isAudioResult, postAudioMessage, publishSharedAudioBus, readSharedAudioBus };
+export type { AnalysisSettings, SharedAudioBus };

--- a/contents/lib/audioBridge.ts
+++ b/contents/lib/audioBridge.ts
@@ -1,7 +1,6 @@
-// An AudioContext and its MediaElementAudioSourceNode belong to the realm that
-// created them, and two extensions share no realm except the page's own, so the
-// graph lives in the page world and only plain data crosses. postMessage rather
-// than CustomEvent detail, which needs cloneInto under Gecko's Xrays.
+// Two extensions share no realm except the page's own, so the graph lives there
+// and only plain data crosses. postMessage rather than CustomEvent detail, which
+// needs cloneInto under Gecko's Xrays.
 
 interface AnalysisSettings {
   audioResponsive: boolean;
@@ -50,8 +49,8 @@ const postAudioMessage = (message: AudioCommand | AudioResult): void => {
   window.postMessage(message, window.location.origin);
 };
 
-// createMediaElementSource may be called once per element for the life of the
-// page. Whichever extension claims it first publishes here; the other reuses.
+// createMediaElementSource may be called once per element, ever. First claimer
+// publishes here, everyone else reuses.
 const AUDIO_BUS_KEY = "__blyricsAudio";
 const AUDIO_BUS_VERSION = 1;
 

--- a/contents/lib/audioBridge.ts
+++ b/contents/lib/audioBridge.ts
@@ -17,6 +17,7 @@ type AudioCommand =
   | { type: "bls-audio-reconnect" };
 
 type AudioResult =
+  | { type: "bls-audio-ready" }
   | { type: "bls-audio-initialized" }
   | { type: "bls-audio-beat"; speedMultiplier: number; scaleMultiplier: number };
 
@@ -27,7 +28,7 @@ const AUDIO_COMMAND_TYPES: readonly string[] = [
   "bls-audio-reconnect",
 ];
 
-const AUDIO_RESULT_TYPES: readonly string[] = ["bls-audio-initialized", "bls-audio-beat"];
+const AUDIO_RESULT_TYPES: readonly string[] = ["bls-audio-ready", "bls-audio-initialized", "bls-audio-beat"];
 
 const messageType = (data: unknown): string | null => {
   if (typeof data !== "object" || data === null) return null;

--- a/contents/lib/audioBridge.ts
+++ b/contents/lib/audioBridge.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/shared/utils/logger";
+
 interface AnalysisSettings {
   audioResponsive: boolean;
   audioBeatThreshold: number;
@@ -73,6 +75,12 @@ const postAudioMessage = (message: AudioCommand | AudioResult): void => {
 const AUDIO_BUS_KEY = "__blyricsAudio";
 const AUDIO_BUS_VERSION = 1;
 
+const AUDIO_BUS_CONTRACT =
+  `window.${AUDIO_BUS_KEY} must be { version, context, source, element } where source.context === context ` +
+  "and source.mediaElement === element. Adopt the context already published on the bus rather than creating " +
+  "a second AudioContext: a media element only ever gets one MediaElementAudioSourceNode, and audio nodes " +
+  "cannot be connected across contexts.";
+
 interface SharedAudioBus {
   version: number;
   context: AudioContext;
@@ -82,19 +90,40 @@ interface SharedAudioBus {
 
 const isSharedAudioBus = (value: unknown): value is SharedAudioBus => {
   if (typeof value !== "object" || value === null) return false;
-  const bus = value as Record<string, unknown>;
+  const { version, context, source, element } = value as Partial<SharedAudioBus>;
   return (
-    typeof bus.version === "number" &&
-    bus.context instanceof AudioContext &&
-    bus.source instanceof MediaElementAudioSourceNode &&
-    bus.element instanceof HTMLMediaElement
+    typeof version === "number" &&
+    context instanceof AudioContext &&
+    source instanceof MediaElementAudioSourceNode &&
+    element instanceof HTMLMediaElement &&
+    source.context === context &&
+    source.mediaElement === element
   );
+};
+
+let hasReportedUnusableBus = false;
+
+const reportUnusableBus = (reason: string): void => {
+  if (hasReportedUnusableBus) return;
+  hasReportedUnusableBus = true;
+  logger.error(`Ignoring a shared audio bus that cannot be adopted (${reason}). ${AUDIO_BUS_CONTRACT}`);
 };
 
 const readSharedAudioBus = (): SharedAudioBus | null => {
   const existing = (window as unknown as Record<string, unknown>)[AUDIO_BUS_KEY];
-  if (!isSharedAudioBus(existing)) return null;
-  return existing.version === AUDIO_BUS_VERSION ? existing : null;
+  if (existing === undefined || existing === null) return null;
+
+  if (!isSharedAudioBus(existing)) {
+    reportUnusableBus("malformed, or its source does not belong to its context and element");
+    return null;
+  }
+
+  if (existing.version !== AUDIO_BUS_VERSION) {
+    reportUnusableBus(`version ${existing.version}, this build speaks version ${AUDIO_BUS_VERSION}`);
+    return null;
+  }
+
+  return existing;
 };
 
 const publishSharedAudioBus = (bus: SharedAudioBus): void => {

--- a/contents/lib/audioBridge.ts
+++ b/contents/lib/audioBridge.ts
@@ -16,29 +16,54 @@ type AudioResult =
   | { type: "bls-audio-initialized" }
   | { type: "bls-audio-beat"; speedMultiplier: number; scaleMultiplier: number };
 
-const AUDIO_COMMAND_TYPES: readonly string[] = [
-  "bls-audio-initialize",
-  "bls-audio-start",
-  "bls-audio-stop",
-  "bls-audio-reconnect",
-];
-
-const AUDIO_RESULT_TYPES: readonly string[] = ["bls-audio-ready", "bls-audio-initialized", "bls-audio-beat"];
-
-const messageType = (data: unknown): string | null => {
-  if (typeof data !== "object" || data === null) return null;
-  const type = (data as { type?: unknown }).type;
-  return typeof type === "string" ? type : null;
+const messageFields = (message: unknown): Record<string, unknown> | null => {
+  if (typeof message !== "object" || message === null) return null;
+  return typeof (message as { type?: unknown }).type === "string" ? (message as Record<string, unknown>) : null;
 };
 
-const isAudioCommand = (data: unknown): data is AudioCommand => {
-  const type = messageType(data);
-  return type !== null && AUDIO_COMMAND_TYPES.includes(type);
+const isFiniteNumber = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+
+const isAnalysisSettings = (value: unknown): value is AnalysisSettings => {
+  if (typeof value !== "object" || value === null) return false;
+  const settings = value as Record<string, unknown>;
+  return (
+    typeof settings.audioResponsive === "boolean" &&
+    isFiniteNumber(settings.audioBeatThreshold) &&
+    isFiniteNumber(settings.audioSpeedMultiplier) &&
+    isFiniteNumber(settings.kawarpAudioScaleBoost)
+  );
 };
 
-const isAudioResult = (data: unknown): data is AudioResult => {
-  const type = messageType(data);
-  return type !== null && AUDIO_RESULT_TYPES.includes(type);
+const isAudioCommand = (message: unknown): message is AudioCommand => {
+  const fields = messageFields(message);
+  if (!fields) return false;
+
+  switch (fields.type) {
+    case "bls-audio-initialize":
+      return typeof fields.showLogs === "boolean";
+    case "bls-audio-start":
+      return typeof fields.showLogs === "boolean" && isAnalysisSettings(fields.settings);
+    case "bls-audio-stop":
+    case "bls-audio-reconnect":
+      return true;
+    default:
+      return false;
+  }
+};
+
+const isAudioResult = (message: unknown): message is AudioResult => {
+  const fields = messageFields(message);
+  if (!fields) return false;
+
+  switch (fields.type) {
+    case "bls-audio-ready":
+    case "bls-audio-initialized":
+      return true;
+    case "bls-audio-beat":
+      return isFiniteNumber(fields.speedMultiplier) && isFiniteNumber(fields.scaleMultiplier);
+    default:
+      return false;
+  }
 };
 
 const postAudioMessage = (message: AudioCommand | AudioResult): void => {
@@ -76,5 +101,12 @@ const publishSharedAudioBus = (bus: SharedAudioBus): void => {
   (window as unknown as Record<string, unknown>)[AUDIO_BUS_KEY] = bus;
 };
 
-export { isAudioCommand, isAudioResult, postAudioMessage, publishSharedAudioBus, readSharedAudioBus };
+export {
+  AUDIO_BUS_VERSION,
+  isAudioCommand,
+  isAudioResult,
+  postAudioMessage,
+  publishSharedAudioBus,
+  readSharedAudioBus,
+};
 export type { AnalysisSettings, SharedAudioBus };

--- a/contents/lib/audioBridge.ts
+++ b/contents/lib/audioBridge.ts
@@ -1,7 +1,3 @@
-// Two extensions share no realm except the page's own, so the graph lives there
-// and only plain data crosses. postMessage rather than CustomEvent detail, which
-// needs cloneInto under Gecko's Xrays.
-
 interface AnalysisSettings {
   audioResponsive: boolean;
   audioBeatThreshold: number;
@@ -49,8 +45,6 @@ const postAudioMessage = (message: AudioCommand | AudioResult): void => {
   window.postMessage(message, window.location.origin);
 };
 
-// createMediaElementSource may be called once per element, ever. First claimer
-// publishes here, everyone else reuses.
 const AUDIO_BUS_KEY = "__blyricsAudio";
 const AUDIO_BUS_VERSION = 1;
 

--- a/contents/lib/audioGraph.ts
+++ b/contents/lib/audioGraph.ts
@@ -216,10 +216,6 @@ const stopAnalysis = (): void => {
     cancelAnimationFrame(state.rafId);
     state.rafId = null;
   }
-  if (state.initTimeoutId !== null) {
-    clearTimeout(state.initTimeoutId);
-    state.initTimeoutId = null;
-  }
   state.lastAnalysisTime = 0;
 };
 
@@ -229,9 +225,7 @@ const reconnect = (): void => {
   const element = currentElement();
   if (!element) return;
 
-  const elementChanged = element !== state.element;
-  const boundElementDetached = state.element !== null && !document.contains(state.element);
-  if (!elementChanged && !boundElementDetached) return;
+  if (element === state.element) return;
 
   logger.log("Audio element changed, reconnecting...");
   if (!bindTo(element)) {

--- a/contents/lib/audioGraph.ts
+++ b/contents/lib/audioGraph.ts
@@ -8,12 +8,9 @@ import {
   type SharedAudioBus,
 } from "./audioBridge";
 
-// The Web Audio half of what contents/lib/audioAnalysis.ts used to do alone;
-// that module is now the isolated-world facade over this one. It runs in the
-// page world, injected by contents/inject-main-world.ts rather than declared as
-// a content script, because Plasmo implements world: "MAIN" through
-// chrome.scripting.registerContentScripts, which has no working equivalent in
-// the Firefox MV2 build.
+// Runs in the page world, injected by contents/inject-main-world.ts rather than
+// declared with Plasmo's world: "MAIN", which throws on the Firefox MV2 build.
+// audioAnalysis.ts is the isolated-world facade over this.
 
 const ANALYSIS_INTERVAL = 100;
 const MIN_VOLUME_FOR_ANALYSIS = 0.005;
@@ -111,8 +108,7 @@ const acquireBus = (element: HTMLMediaElement): SharedAudioBus | null => {
   }
   claimedElements.add(element);
 
-  // Only the owner routes to the destination; reusing a bus and connecting again
-  // would play the original twice.
+  // Only the owner routes to the destination, or the original plays twice.
   source.connect(context.destination);
 
   const bus: SharedAudioBus = { version: 1, context, source, element };
@@ -134,8 +130,7 @@ const bindTo = (element: HTMLMediaElement): boolean => {
 const initialize = (): void => {
   if (state.isInitialized) return;
 
-  // A repeated initialize command must not leave a second retry timer behind,
-  // or every command doubles the polling rate for as long as no element exists.
+  // Without this, every repeated command doubles the retry rate.
   if (state.initTimeoutId !== null) {
     clearTimeout(state.initTimeoutId);
     state.initTimeoutId = null;

--- a/contents/lib/audioGraph.ts
+++ b/contents/lib/audioGraph.ts
@@ -44,7 +44,12 @@ const state: GraphState = {
   lastAnalysisTime: 0,
 };
 
-const elementSources = new WeakMap<HTMLMediaElement, MediaElementAudioSourceNode | null>();
+interface ElementCapture {
+  context: AudioContext;
+  source: MediaElementAudioSourceNode;
+}
+
+const elementCaptures = new WeakMap<HTMLMediaElement, ElementCapture | null>();
 
 const currentElement = (): HTMLMediaElement | null => document.querySelector(PLAYER_MEDIA_SELECTOR);
 
@@ -89,17 +94,18 @@ const ownContext = (): AudioContext => {
   return state.context;
 };
 
-const sourceFor = (context: AudioContext, element: HTMLMediaElement): MediaElementAudioSourceNode | null => {
-  const cached = elementSources.get(element);
+const captureFor = (preferredContext: AudioContext, element: HTMLMediaElement): ElementCapture | null => {
+  const cached = elementCaptures.get(element);
   if (cached !== undefined) return cached;
 
   try {
-    const source = context.createMediaElementSource(element);
-    source.connect(context.destination);
-    elementSources.set(element, source);
-    return source;
+    const source = preferredContext.createMediaElementSource(element);
+    source.connect(preferredContext.destination);
+    const capture: ElementCapture = { context: preferredContext, source };
+    elementCaptures.set(element, capture);
+    return capture;
   } catch (error) {
-    elementSources.set(element, null);
+    elementCaptures.set(element, null);
     logger.error("Could not capture the audio element, effects will not react to sound:", error);
     return null;
   }
@@ -108,18 +114,23 @@ const sourceFor = (context: AudioContext, element: HTMLMediaElement): MediaEleme
 const acquireBus = (element: HTMLMediaElement): SharedAudioBus | null => {
   const shared = readSharedAudioBus();
   if (shared && shared.element === element) {
+    elementCaptures.set(element, { context: shared.context, source: shared.source });
     attachResumeOnGesture(shared.context);
     logger.log("Audio analysis attached to an existing shared bus");
     return shared;
   }
 
-  const context = shared?.context ?? ownContext();
-  attachResumeOnGesture(context);
+  const capture = captureFor(shared?.context ?? ownContext(), element);
+  if (!capture) return null;
 
-  const source = sourceFor(context, element);
-  if (!source) return null;
+  attachResumeOnGesture(capture.context);
 
-  const bus: SharedAudioBus = { version: AUDIO_BUS_VERSION, context, source, element };
+  const bus: SharedAudioBus = {
+    version: AUDIO_BUS_VERSION,
+    context: capture.context,
+    source: capture.source,
+    element,
+  };
   publishSharedAudioBus(bus);
   return bus;
 };

--- a/contents/lib/audioGraph.ts
+++ b/contents/lib/audioGraph.ts
@@ -8,10 +8,6 @@ import {
   type SharedAudioBus,
 } from "./audioBridge";
 
-// Runs in the page world, injected by contents/inject-main-world.ts rather than
-// declared with Plasmo's world: "MAIN", which throws on the Firefox MV2 build.
-// audioAnalysis.ts is the isolated-world facade over this.
-
 const ANALYSIS_INTERVAL = 100;
 const MIN_VOLUME_FOR_ANALYSIS = 0.005;
 const INIT_RETRY_MS = 1000;
@@ -108,7 +104,6 @@ const acquireBus = (element: HTMLMediaElement): SharedAudioBus | null => {
   }
   claimedElements.add(element);
 
-  // Only the owner routes to the destination, or the original plays twice.
   source.connect(context.destination);
 
   const bus: SharedAudioBus = { version: 1, context, source, element };
@@ -130,7 +125,6 @@ const bindTo = (element: HTMLMediaElement): boolean => {
 const initialize = (): void => {
   if (state.isInitialized) return;
 
-  // Without this, every repeated command doubles the retry rate.
   if (state.initTimeoutId !== null) {
     clearTimeout(state.initTimeoutId);
     state.initTimeoutId = null;

--- a/contents/lib/audioGraph.ts
+++ b/contents/lib/audioGraph.ts
@@ -1,6 +1,8 @@
+import { PLAYER_MEDIA_SELECTOR } from "@/shared/constants/mediaElements";
 import { logger } from "@/shared/utils/logger";
 import {
   type AnalysisSettings,
+  AUDIO_BUS_VERSION,
   isAudioCommand,
   postAudioMessage,
   publishSharedAudioBus,
@@ -42,27 +44,27 @@ const state: GraphState = {
   lastAnalysisTime: 0,
 };
 
-const claimedElements = new WeakSet<HTMLMediaElement>();
+const elementSources = new WeakMap<HTMLMediaElement, MediaElementAudioSourceNode | null>();
 
-const currentElement = (): HTMLMediaElement | null => document.querySelector("audio, video");
+const currentElement = (): HTMLMediaElement | null => document.querySelector(PLAYER_MEDIA_SELECTOR);
+
+const detachResumeOnGesture = (): void => {
+  if (!state.resumeContextHandler) return;
+  document.removeEventListener("click", state.resumeContextHandler);
+  document.removeEventListener("keydown", state.resumeContextHandler);
+  state.resumeContextHandler = null;
+};
 
 const attachResumeOnGesture = (context: AudioContext): void => {
   if (context.state !== "suspended") return;
 
-  if (state.resumeContextHandler) {
-    document.removeEventListener("click", state.resumeContextHandler);
-    document.removeEventListener("keydown", state.resumeContextHandler);
-  }
+  detachResumeOnGesture();
 
   state.resumeContextHandler = async () => {
-    if (state.context && state.context.state === "suspended") {
-      await state.context.resume();
+    if (context.state === "suspended") {
+      await context.resume();
     }
-    if (state.resumeContextHandler) {
-      document.removeEventListener("click", state.resumeContextHandler);
-      document.removeEventListener("keydown", state.resumeContextHandler);
-      state.resumeContextHandler = null;
-    }
+    detachResumeOnGesture();
   };
 
   document.addEventListener("click", state.resumeContextHandler);
@@ -70,7 +72,9 @@ const attachResumeOnGesture = (context: AudioContext): void => {
 };
 
 const buildAnalyser = (context: AudioContext, source: MediaElementAudioSourceNode): void => {
-  state.analyser?.disconnect();
+  if (state.source && state.analyser) {
+    state.source.disconnect(state.analyser);
+  }
   state.analyser = context.createAnalyser();
   state.analyser.fftSize = ANALYSER_FFT_SIZE;
   state.analyser.smoothingTimeConstant = ANALYSER_SMOOTHING;
@@ -78,35 +82,44 @@ const buildAnalyser = (context: AudioContext, source: MediaElementAudioSourceNod
   source.connect(state.analyser);
 };
 
+const ownContext = (): AudioContext => {
+  if (!state.context) {
+    state.context = new AudioContext();
+  }
+  return state.context;
+};
+
+const sourceFor = (context: AudioContext, element: HTMLMediaElement): MediaElementAudioSourceNode | null => {
+  const cached = elementSources.get(element);
+  if (cached !== undefined) return cached;
+
+  try {
+    const source = context.createMediaElementSource(element);
+    source.connect(context.destination);
+    elementSources.set(element, source);
+    return source;
+  } catch (error) {
+    elementSources.set(element, null);
+    logger.error("Could not capture the audio element, effects will not react to sound:", error);
+    return null;
+  }
+};
+
 const acquireBus = (element: HTMLMediaElement): SharedAudioBus | null => {
   const shared = readSharedAudioBus();
   if (shared && shared.element === element) {
+    attachResumeOnGesture(shared.context);
     logger.log("Audio analysis attached to an existing shared bus");
     return shared;
   }
 
-  if (claimedElements.has(element)) {
-    logger.error("This element was already claimed and can never be routed again. Reload the page.");
-    return null;
-  }
-
-  const context = new AudioContext();
+  const context = shared?.context ?? ownContext();
   attachResumeOnGesture(context);
 
-  let source: MediaElementAudioSourceNode;
-  try {
-    source = context.createMediaElementSource(element);
-  } catch (error) {
-    claimedElements.add(element);
-    logger.error("Could not capture the audio element, effects will not react to sound:", error);
-    void context.close();
-    return null;
-  }
-  claimedElements.add(element);
+  const source = sourceFor(context, element);
+  if (!source) return null;
 
-  source.connect(context.destination);
-
-  const bus: SharedAudioBus = { version: 1, context, source, element };
+  const bus: SharedAudioBus = { version: AUDIO_BUS_VERSION, context, source, element };
   publishSharedAudioBus(bus);
   return bus;
 };
@@ -115,10 +128,10 @@ const bindTo = (element: HTMLMediaElement): boolean => {
   const bus = acquireBus(element);
   if (!bus) return false;
 
+  buildAnalyser(bus.context, bus.source);
   state.context = bus.context;
   state.source = bus.source;
   state.element = element;
-  buildAnalyser(bus.context, bus.source);
   return true;
 };
 
@@ -137,7 +150,10 @@ const initialize = (): void => {
       return;
     }
 
-    if (!bindTo(element)) return;
+    if (!bindTo(element)) {
+      state.initTimeoutId = window.setTimeout(initialize, INIT_RETRY_MS);
+      return;
+    }
 
     state.isInitialized = true;
     postAudioMessage({ type: "bls-audio-initialized" });
@@ -218,22 +234,24 @@ const reconnect = (): void => {
   if (!elementChanged && !boundElementDetached) return;
 
   logger.log("Audio element changed, reconnecting...");
-  bindTo(element);
+  if (!bindTo(element)) {
+    logger.error("Could not rebind audio analysis to the current media element");
+  }
 };
 
 window.addEventListener("message", event => {
   if (event.source !== window || event.origin !== window.location.origin) return;
-  const data: unknown = event.data;
-  if (!isAudioCommand(data)) return;
+  const message: unknown = event.data;
+  if (!isAudioCommand(message)) return;
 
-  switch (data.type) {
+  switch (message.type) {
     case "bls-audio-initialize":
-      logger.setEnabled(data.showLogs);
+      logger.setEnabled(message.showLogs);
       initialize();
       break;
     case "bls-audio-start":
-      logger.setEnabled(data.showLogs);
-      startAnalysis(data.settings);
+      logger.setEnabled(message.showLogs);
+      startAnalysis(message.settings);
       break;
     case "bls-audio-stop":
       stopAnalysis();

--- a/contents/lib/audioGraph.ts
+++ b/contents/lib/audioGraph.ts
@@ -1,4 +1,3 @@
-import type { PlasmoCSConfig } from "plasmo";
 import { logger } from "@/shared/utils/logger";
 import {
   type AnalysisSettings,
@@ -7,16 +6,14 @@ import {
   publishSharedAudioBus,
   readSharedAudioBus,
   type SharedAudioBus,
-} from "./lib/audioBridge";
+} from "./audioBridge";
 
 // The Web Audio half of what contents/lib/audioAnalysis.ts used to do alone;
-// that module is now the isolated-world facade over this one.
-
-export const config: PlasmoCSConfig = {
-  matches: ["https://music.youtube.com/*"],
-  all_frames: false,
-  world: "MAIN",
-};
+// that module is now the isolated-world facade over this one. It runs in the
+// page world, injected by contents/inject-main-world.ts rather than declared as
+// a content script, because Plasmo implements world: "MAIN" through
+// chrome.scripting.registerContentScripts, which has no working equivalent in
+// the Firefox MV2 build.
 
 const ANALYSIS_INTERVAL = 100;
 const MIN_VOLUME_FOR_ANALYSIS = 0.005;
@@ -137,13 +134,19 @@ const bindTo = (element: HTMLMediaElement): boolean => {
 const initialize = (): void => {
   if (state.isInitialized) return;
 
+  // A repeated initialize command must not leave a second retry timer behind,
+  // or every command doubles the polling rate for as long as no element exists.
+  if (state.initTimeoutId !== null) {
+    clearTimeout(state.initTimeoutId);
+    state.initTimeoutId = null;
+  }
+
   try {
     const element = currentElement();
     if (!element) {
       state.initTimeoutId = window.setTimeout(initialize, INIT_RETRY_MS);
       return;
     }
-    state.initTimeoutId = null;
 
     if (!bindTo(element)) return;
 
@@ -251,3 +254,5 @@ window.addEventListener("message", event => {
       break;
   }
 });
+
+postAudioMessage({ type: "bls-audio-ready" });

--- a/contents/lib/gradientController.ts
+++ b/contents/lib/gradientController.ts
@@ -56,12 +56,14 @@ const handlePlaybackStateChange = (isPlaying: boolean): void => {
 };
 
 const handleAudioResponsiveToggle = (): void => {
-  if (gradientSettings.audioResponsive && audioAnalysis.isAudioInitialized()) {
+  if (gradientSettings.audioResponsive) {
     audioAnalysis.startAudioAnalysis(gradientSettings, handleBeatDetected);
-  } else {
-    dynamicMultipliers = { speedMultiplier: 1, scaleMultiplier: 1 };
-    kawarpManager.updateKawarpSpeed(gradientSettings, dynamicMultipliers);
+    return;
   }
+
+  audioAnalysis.stopAudioAnalysis();
+  dynamicMultipliers = { speedMultiplier: 1, scaleMultiplier: 1 };
+  kawarpManager.updateKawarpSpeed(gradientSettings, dynamicMultipliers);
 };
 
 const destroyBrowsePageEffects = (): void => {

--- a/contents/youtube-music.ts
+++ b/contents/youtube-music.ts
@@ -38,7 +38,7 @@ const initializeApp = async (): Promise<void> => {
     clearAnimatedArtCache: animatedArtManager.clearCache,
   });
 
-  audioAnalysis.initializeAudioAnalysis();
+  audioAnalysis.initializeAudioAnalysis(settings.showLogs);
 
   setTimeout(async () => {
     await gradientController.checkAndUpdateGradient();

--- a/shared/constants/mediaElements.ts
+++ b/shared/constants/mediaElements.ts
@@ -1,0 +1,3 @@
+export const ANIMATED_ART_VIDEO_ID = "bls-video";
+
+export const PLAYER_MEDIA_SELECTOR = `audio, video:not(#${ANIMATED_ART_VIDEO_ID})`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
       "@/popup/*": ["./popup/*"]
     }
   },
+  "files": ["./node_modules/plasmo/templates/plasmo.d.ts"],
   "include": [".plasmo/index.d.ts", "**/*"],
   "exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
## Overview

Only one extension can ever pull an audio source off the player element, so whichever loaded first won and the other one got silence. Move the audio graph into the page world and publish the context and source there, letting tacet and shaders both attach to the same graph instead of racing for it. Beat detection runs off that shared graph now and reports back to the rest of the extension over messages.
